### PR TITLE
Update native module filter

### DIFF
--- a/tasks/list_modules.js
+++ b/tasks/list_modules.js
@@ -13,11 +13,6 @@ const abcsort = function (a, b) {
 };
 
 
-const natives = Object.keys(process.binding("natives"))
-    .filter(nativeDep => nativeDep[0] !== '_')
-    .map(dep => ({name: dep, version: 'native'}))
-    .sort(abcsort);
-
 const manifest = require(Path.join(process.env.VERQUIRE_DIR, 'packages.json'));
 
 
@@ -40,6 +35,6 @@ const modules = Object.keys(manifest).reduce((acc, module_name) => {
 module.exports = cb => {
     cb(null, {
         node_version: process.version,
-        modules: natives.concat(modules)
+        modules: modules
     });
 };

--- a/tasks/list_modules.js
+++ b/tasks/list_modules.js
@@ -13,6 +13,15 @@ const abcsort = function (a, b) {
 };
 
 
+const natives = Object.keys(process.binding("natives"))
+    .filter(nativeDep => !nativeDep.startsWith('internal/') && 
+        !nativeDep.startsWith('node-inspect/') &&
+        !nativeDep.startsWith('_') &&
+        !nativeDep.startsWith('v8/')
+    )
+    .map(dep => ({name: dep, version: 'native'}))
+    .sort(abcsort);
+
 const manifest = require(Path.join(process.env.VERQUIRE_DIR, 'packages.json'));
 
 
@@ -35,6 +44,6 @@ const modules = Object.keys(manifest).reduce((acc, module_name) => {
 module.exports = cb => {
     cb(null, {
         node_version: process.version,
-        modules: modules
+        modules: natives.concat(modules)
     });
 };


### PR DESCRIPTION
## ✏️ Changes

Add additional filtering on native modules to prevent confusion of the `require('*')` statement.

## Reference

https://auth0team.atlassian.net/browse/ESD-10704

## Deployment

This will be manually deployed (copy pasted to the webtask hosting the code)