### PR TITLE
feat: remove request link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ Where `node_version` can be either `8` or `12` (the default).
 > **Please note that [Node.js v8 is now officially out of LTS](https://github.com/nodejs/Release#release-schedule) and we strongly encourage you to migrate to Node 12 as soon as possible.**
 > **We cannot support increased functionality on Node 8. If you are looking to update your code or add new packages, you need to reference Node 12 packages which we support.**
 
-## New Package Requests
-
-Can't find the module you want? You can [request it here](https://github.com/auth0-extensions/canirequire/issues/new).
-
-
 ## Development Instructions
 
 1. ```npm i```

--- a/index.html
+++ b/index.html
@@ -31,12 +31,6 @@
           <input type="text" class="input-main grey-text webtask-red-border" placeholder="e.g. mongodb" name="modules-filter">
         </div>
       </div>
-      <div class="col s12">
-        <div class="center">
-          Can't find the module you want? <a class="webtask-red-text" href="https://github.com/auth0-extensions/canirequire/issues/new">Request it</a>!
-        </div>
-      </div>
-      <br><br>
     </div>
   </div>
   <section id="canirequire-modules">


### PR DESCRIPTION
## ✏️ Changes

Removes the link to request new packages from canirequire.

## 📷 Screenshots

### Before
 
<img width="1920" alt="Screenshot 2024-01-28 at 12 10 24 PM" src="https://github.com/auth0-extensions/canirequire/assets/9423051/2e2f6c9e-3f83-4094-8520-d31b5993344c">

### After

<img width="1920" alt="Screenshot 2024-01-28 at 12 10 14 PM" src="https://github.com/auth0-extensions/canirequire/assets/9423051/ddc39b38-175f-4da5-8054-57975d352dc0">

## 🔗 References
  
N/A
  
## 🎯 Testing
     
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
✅ This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will visit https://auth0-extensions.github.io/canirequire/ to confirm the changes have been applied.
  
## 🔥 Rollback
  
N/A

### 📄 Procedure

N/A 

## 🖥 Appliance
  
N/A